### PR TITLE
SavedRecipes Screen

### DIFF
--- a/app/src/main/java/com/example/fond/adapters/RecipeSavedAdapter.java
+++ b/app/src/main/java/com/example/fond/adapters/RecipeSavedAdapter.java
@@ -1,0 +1,93 @@
+package com.example.fond.adapters;
+
+import android.content.Context;
+import android.text.Layout;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bumptech.glide.Glide;
+import com.example.fond.R;
+import com.example.fond.models.ParseRecipe;
+
+import java.util.List;
+
+public class RecipeSavedAdapter extends RecyclerView.Adapter<RecipeSavedAdapter.ViewHolder> {
+
+    private Context context;
+    private List<ParseRecipe> parseRecipes;
+
+    public RecipeSavedAdapter(Context context, List<ParseRecipe> recipes ){
+        this.context = context;
+        this.parseRecipes = recipes;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        Context context = parent.getContext();
+        LayoutInflater inflater = LayoutInflater.from(context);
+
+        View recipeView = inflater.inflate(R.layout.item_recipe, parent, false);
+
+        ViewHolder viewHolder = new ViewHolder(recipeView);
+        return viewHolder;
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        ParseRecipe parseRecipe = parseRecipes.get(position);
+        holder.bind(parseRecipe);
+    }
+
+    @Override
+    public int getItemCount() {
+        return parseRecipes.size();
+    }
+
+    public void clear(){
+        parseRecipes.clear();
+        notifyDataSetChanged();
+    }
+
+    public void addAll(List<ParseRecipe> parseRecipeList){
+        parseRecipes.addAll(parseRecipeList);
+        notifyDataSetChanged();
+    }
+
+    public void updateAll(List<ParseRecipe> parseRecipeList){
+        this.parseRecipes = parseRecipeList;
+        notifyDataSetChanged();
+    }
+
+
+    public class ViewHolder extends RecyclerView.ViewHolder {
+        public ImageView ivRecipeImage;
+        public TextView tvRecipeTitle;
+        public TextView tvRecipeSummary;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+
+            ivRecipeImage = itemView.findViewById(R.id.ivRecipeImage);
+            tvRecipeTitle = itemView.findViewById(R.id.tvRecipeTitle);
+            tvRecipeSummary = itemView.findViewById(R.id.tvRecipeSummary);
+
+        }
+
+        public void bind(ParseRecipe parseRecipe) {
+            tvRecipeSummary.setText(parseRecipe.getSummary());
+            tvRecipeTitle.setText(parseRecipe.getTitle());
+            Glide
+                    .with(context)
+                    .load(parseRecipe.getImageUrl())
+                    .into(ivRecipeImage);
+        }
+    }
+}

--- a/app/src/main/java/com/example/fond/models/ParseRecipe.java
+++ b/app/src/main/java/com/example/fond/models/ParseRecipe.java
@@ -1,0 +1,51 @@
+package com.example.fond.models;
+
+import com.parse.ParseClassName;
+import com.parse.ParseObject;
+
+@ParseClassName("ParseRecipe")
+public class ParseRecipe extends ParseObject {
+
+    public static final String KEY_TITLE = "title";
+    public static final String KEY_IMAGE_URL = "imageUrl";
+    public static final String KEY_SUMMARY = "summary";
+    public static final String KEY_SPOONACULAR_RECIPEID = "recipeId";
+
+    public ParseRecipe() { super(); }
+
+    public String getTitle() {
+        return getString(KEY_TITLE);
+    }
+
+    public void setTitle(String title){
+        put(KEY_TITLE, title);
+    }
+
+    public String getImageUrl() {
+        return getString(KEY_IMAGE_URL);
+    }
+
+    public void setImageUrl(String imageUrl) {
+        put(KEY_IMAGE_URL, imageUrl);
+    }
+
+    public String getSummary() {
+        return getString(KEY_SUMMARY);
+    }
+
+    public void setSummary(String summary){
+        put(KEY_SUMMARY, summary);
+    }
+
+    public void setRecipeId(Integer recipeId){
+        put(KEY_SPOONACULAR_RECIPEID, recipeId);
+    }
+
+    public int getRecipeId() {
+        return getInt(KEY_SPOONACULAR_RECIPEID);
+    }
+
+
+
+
+}

--- a/app/src/main/java/com/example/fond/models/RecipeFavorites.java
+++ b/app/src/main/java/com/example/fond/models/RecipeFavorites.java
@@ -1,0 +1,17 @@
+package com.example.fond.models;
+
+import com.parse.ParseClassName;
+import com.parse.ParseObject;
+import com.parse.ParseUser;
+
+@ParseClassName("Recipe_Favorites")
+public class RecipeFavorites extends ParseObject {
+    public static final String KEY_USER = "userId";
+    public static final String KEY_RECIPE = "recipeId";
+
+    public ParseUser getUser(){return getParseUser(KEY_USER);}
+    public void setUser(ParseUser user) {put(KEY_USER, user);}
+
+    public ParseRecipe getRecipe(){return (ParseRecipe) getParseObject(KEY_RECIPE);}
+    public void setRecipe(ParseRecipe recipe) {put(KEY_RECIPE, recipe);}
+}

--- a/app/src/main/java/com/example/fond/networking/ParseApplication.java
+++ b/app/src/main/java/com/example/fond/networking/ParseApplication.java
@@ -3,6 +3,8 @@ package com.example.fond.networking;
 import android.app.Application;
 
 import com.example.fond.BuildConfig;
+import com.example.fond.models.ParseRecipe;
+import com.example.fond.models.RecipeFavorites;
 import com.example.fond.models.UserPost;
 import com.parse.Parse;
 import com.parse.ParseObject;
@@ -18,6 +20,13 @@ public class ParseApplication extends Application {
 
         // Registering the UserPost class
         ParseObject.registerSubclass(UserPost.class);
+
+        // Register the ParseRecipe class
+
+        ParseObject.registerSubclass(ParseRecipe.class);
+
+
+        ParseObject.registerSubclass(RecipeFavorites.class);
 
         // Initializing the Parse SDK
         Parse.initialize(new Parse.Configuration.Builder(this)

--- a/app/src/main/res/layout/fragment_saved_recipes.xml
+++ b/app/src/main/res/layout/fragment_saved_recipes.xml
@@ -1,22 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".fragments.SavedRecipesFragment">
 
     <include
-        layout="@layout/toolbar_main"/>
+        android:id="@+id/toolbar"
+        layout="@layout/toolbar_main" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvSavedRecipes"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_below="@+id/toolbar" />
 
     <!-- TODO: Update blank fragment layout -->
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:text="Saved Recipes"
-        android:textAllCaps="false"
-        android:textSize="24sp"
-        android:textStyle="bold" />
-
-</FrameLayout>
+</RelativeLayout>


### PR DESCRIPTION
Closes #35 
Closes #76 
Close #53 
Added adapter and functionality to query for a user's favorited recipes, and then display those on the saved recipes feed.

How to test:
- [ ] Sign into PandemicBaker test account (I have set it up so that one recipe is saved w/ this user in the recipe_favorites parse db)
- [ ] Navigate to saved fragment
- [ ] Check that the recipe shows up (Should show Cream Cheese Stuffed Chicken Breasts)
- [ ] Sign into a different account
- [ ] Navigate to saved fragment
- [ ] No recipes should show up 

(Note: alternatively you could add your own row in Parse db, recipe_favorites table)